### PR TITLE
add alpha channel data to psd document image(flatten image).

### DIFF
--- a/section_image_data.go
+++ b/section_image_data.go
@@ -46,7 +46,10 @@ func readImageData(doc *Document) {
 			red := byte(chanData[0][i])
 			green := byte(chanData[1][i])
 			blue := byte(chanData[2][i])
-			alpha := byte(chanData[3][i])
+			alpha := byte(255)
+			if len(chanData) > 3 {
+				alpha = byte(chanData[3][i])
+			}
 			image.Set(x, y, color.RGBA{red, green, blue, alpha})
 		}
 	}

--- a/section_image_data.go
+++ b/section_image_data.go
@@ -46,7 +46,8 @@ func readImageData(doc *Document) {
 			red := byte(chanData[0][i])
 			green := byte(chanData[1][i])
 			blue := byte(chanData[2][i])
-			image.Set(x, y, color.RGBA{red, green, blue, 255})
+			alpha := byte(chanData[3][i])
+			image.Set(x, y, color.RGBA{red, green, blue, alpha})
 		}
 	}
 	doc.Image = image


### PR DESCRIPTION
PSD file format may contain alpha channels in the flattened image.